### PR TITLE
Correct end game room deletion

### DIFF
--- a/app/src/androidTest/java/ch/epfl/sweng/SDP/game/LoadingScreenActivityTest.java
+++ b/app/src/androidTest/java/ch/epfl/sweng/SDP/game/LoadingScreenActivityTest.java
@@ -1,43 +1,15 @@
 package ch.epfl.sweng.SDP.game;
 
-import android.support.test.espresso.Espresso;
-import android.support.test.espresso.UiController;
-import android.support.test.espresso.ViewAction;
-import android.support.test.espresso.intent.Intents;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
-import android.view.KeyEvent;
-import android.view.View;
 
-import com.google.firebase.database.DataSnapshot;
-
-import org.hamcrest.Matcher;
-import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mockito;
 
 import java.util.ArrayList;
-import java.util.Vector;
-import java.util.concurrent.TimeUnit;
 
-import ch.epfl.sweng.SDP.R;
-import ch.epfl.sweng.SDP.game.drawing.DrawingActivity;
-import ch.epfl.sweng.SDP.home.HomeActivity;
-
-import static android.support.test.espresso.Espresso.onView;
-import static android.support.test.espresso.action.ViewActions.click;
-import static android.support.test.espresso.assertion.ViewAssertions.matches;
-import static android.support.test.espresso.intent.Intents.intended;
-import static android.support.test.espresso.intent.matcher.IntentMatchers.hasComponent;
-import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
-import static android.support.test.espresso.matcher.ViewMatchers.isRoot;
-import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static ch.epfl.sweng.SDP.game.LoadingScreenActivity.disableLoadingAnimations;
-import static ch.epfl.sweng.SDP.game.WaitingPageActivityTest.waitFor;
-import static junit.framework.Assert.assertTrue;
 
 @RunWith(AndroidJUnit4.class)
 public class LoadingScreenActivityTest {

--- a/app/src/androidTest/java/ch/epfl/sweng/SDP/game/VotingPageActivityTest.java
+++ b/app/src/androidTest/java/ch/epfl/sweng/SDP/game/VotingPageActivityTest.java
@@ -123,7 +123,7 @@ public class VotingPageActivityTest {
     @Test
     public void testStateChange() {
         when(dataSnapshotMock.getValue(Integer.class)).thenReturn(4);
-        mActivityRule.getActivity().listenerState.onDataChange(dataSnapshotMock);
+        mActivityRule.getActivity().callOnStateChange(dataSnapshotMock);
         SystemClock.sleep(2000);
         RankingFragment myFragment = (RankingFragment) mActivityRule.getActivity()
                 .getSupportFragmentManager().findFragmentById(R.id.votingPageLayout);

--- a/app/src/main/java/ch/epfl/sweng/SDP/game/RankingFragment.java
+++ b/app/src/main/java/ch/epfl/sweng/SDP/game/RankingFragment.java
@@ -16,6 +16,7 @@ import com.google.firebase.database.DatabaseReference;
 import com.google.firebase.database.ValueEventListener;
 
 import ch.epfl.sweng.SDP.R;
+import ch.epfl.sweng.SDP.auth.Account;
 import ch.epfl.sweng.SDP.firebase.Database;
 import ch.epfl.sweng.SDP.utils.SortUtils;
 
@@ -85,20 +86,9 @@ public class RankingFragment extends ListFragment {
     }
 
     private void setFinishedCollectingRanking() {
-        finishedRef.addListenerForSingleValueEvent(new ValueEventListener() {
-            @Override
-            public void onDataChange(@NonNull DataSnapshot dataSnapshot) {
-                Integer value = dataSnapshot.getValue(Integer.class);
-                if (value != null) {
-                    finishedRef.setValue(++value);
-                }
-            }
+        finishedRef.child(Account.getInstance(getActivity()
+                .getApplicationContext()).getUsername()).setValue(1);
 
-            @Override
-            public void onCancelled(@NonNull DatabaseError databaseError) {
-                throw databaseError.toException();
-            }
-        });
     }
 
     private class RankingAdapter extends ArrayAdapter<String> {

--- a/app/src/main/java/ch/epfl/sweng/SDP/game/VotingPageActivity.java
+++ b/app/src/main/java/ch/epfl/sweng/SDP/game/VotingPageActivity.java
@@ -358,39 +358,21 @@ public class VotingPageActivity extends Activity {
     }
 
     private void startRankingFragment() {
-        rankingRef.addListenerForSingleValueEvent(new ValueEventListener() {
-            @Override
-            public void onDataChange(@NonNull DataSnapshot dataSnapshot) {
-                String[] ranking = new String[NUMBER_OF_DRAWINGS];
-                short counter = 0;
+        // Prepare a Bundle for passing the ranking array to the fragment
+        Bundle bundle = new Bundle();
+        bundle.putString("roomID", roomID);
 
-                // Get the final ranking
-                for (DataSnapshot snapshot : dataSnapshot.getChildren()) {
-                    ranking[counter++] = snapshot.getKey();
-                }
+        // Clear the UI; buttonChangeImage and rankingButton need
+        // to be removed after testing
+        setVisibility(View.GONE, R.id.ratingBar, R.id.drawing,
+                R.id.playerNameView, R.id.timer);
 
-                // Prepare a Bundle for passing the ranking array to the fragment
-                Bundle bundle = new Bundle();
-                bundle.putString("roomID", roomID);
-
-                // Clear the UI; buttonChangeImage and rankingButton need
-                // to be removed after testing
-                setVisibility(View.GONE, R.id.ratingBar, R.id.drawing,
-                        R.id.playerNameView, R.id.timer);
-
-                // Create and show the final ranking in the new fragment
-                getSupportFragmentManager().beginTransaction()
-                        .add(R.id.votingPageLayout,
-                                RankingFragment.instantiate(getApplicationContext(),
-                                        RankingFragment.class.getName(), bundle))
-                        .addToBackStack(null).commit();
-            }
-
-            @Override
-            public void onCancelled(@NonNull DatabaseError databaseError) {
-                throw databaseError.toException();
-            }
-        });
+        // Create and show the final ranking in the new fragment
+        getSupportFragmentManager().beginTransaction()
+                .add(R.id.votingPageLayout,
+                        RankingFragment.instantiate(getApplicationContext(),
+                                RankingFragment.class.getName(), bundle))
+                .addToBackStack(null).commit();
     }
 
     /**

--- a/app/src/main/java/ch/epfl/sweng/SDP/game/VotingPageActivity.java
+++ b/app/src/main/java/ch/epfl/sweng/SDP/game/VotingPageActivity.java
@@ -426,11 +426,11 @@ public class VotingPageActivity extends Activity {
     }
 
     @VisibleForTesting
-    public void callSetLayoutVisibility() {
+    public void callOnStateChange(final DataSnapshot dataSnapshot) {
         this.runOnUiThread(new Runnable() {
             @Override
             public void run() {
-                setLayoutToVisible();
+                listenerState.onDataChange(dataSnapshot);
             }
         });
     }

--- a/app/src/main/java/ch/epfl/sweng/SDP/game/WaitingPageActivity.java
+++ b/app/src/main/java/ch/epfl/sweng/SDP/game/WaitingPageActivity.java
@@ -429,8 +429,8 @@ public class WaitingPageActivity extends Activity {
             Matchmaker.getInstance(Account.getInstance(this)).leaveRoom(roomID);
             if(hasVoted) {
                 String wordVoted = isWord1Voted ? word1 : word2;
-                DatabaseReference wordRef = database.getReference(TOP_ROOM_NODE_ID + "." +
-                                                            roomID + ".words." + wordVoted);
+                DatabaseReference wordRef = database.getReference(TOP_ROOM_NODE_ID + "."
+                                                            + roomID + ".words." + wordVoted);
                 removeVote(wordRef);
             }
         }

--- a/functions/index.js
+++ b/functions/index.js
@@ -20,7 +20,7 @@ var state = 0;
 
 admin.initializeApp();
 
-function checkUsersReady(state, path, snapshot) {
+function checkUsersReady(path, snapshot) {
   if(snapshot.child("users").numChildren() === maxPlayers) {
     if(snapshot.child("state").val() === StateEnum.Idle || 
       snapshot.child("state").val() === StateEnum.EndVoting) {
@@ -31,6 +31,18 @@ function checkUsersReady(state, path, snapshot) {
     console.log("Not ready");
   }
   return;
+}
+
+// Check if all the values childs of a node are true i.e. the values are set to 1
+function checkNodeTrue(snapshot) {
+  let ready = true;
+  snapshot.forEach((child) => {
+    if(child.val() !== 1) {
+      ready = false;
+    }
+  });
+
+  return ready;
 }
 
 function functionTimer (seconds, state, roomID, call) {
@@ -121,17 +133,20 @@ exports.joinGame = functions.https.onRequest((req, res) => {
 });
 
 exports.joinGame2 = functions.https.onCall((data, context) => {
-  console.log("Started method");
   // Grab the text parameter.
   const id = data.id;
   const username = data.username;
+  const league = 1;
   let _roomID;
   console.log(username);
   var alreadyJoined = false;
+  let roomsList = [];
 
   return admin.database().ref(parentRoomID).once('value', (snapshot) => {
     return snapshot.forEach((roomID) => {
+
       const playingVal = roomID.child("playing").val();
+      roomsList.push(parseInt(roomID.key, 10));
 
       // Check if the room is full, if the user already joined a room and if 
       // the game is not already playing
@@ -140,6 +155,7 @@ exports.joinGame2 = functions.https.onCall((data, context) => {
         const userCount = "user" +  (roomID.child("users").numChildren() + 1).toString();
         const path = parentRoomID + roomID.key;
         _roomID = roomID.key;
+
         if(roomID.hasChild("users")) {
           if(roomID.child("users/" + id).exists()) {
             admin.database().ref(path).child("users/" + id).remove();
@@ -155,6 +171,10 @@ exports.joinGame2 = functions.https.onCall((data, context) => {
       }
     });
   }).then(() => {
+    if(alreadyJoined === false) {
+        _roomID = createRoomAndJoin(league, roomsList, username, id);
+    }
+    console.log(_roomID);
     return _roomID;
   });
 });
@@ -184,20 +204,63 @@ function addWordsToDatabase(roomID) {
 
 }
 
+function generateRoomID(league, roomsList) {
+  const minRoomID = league * 100;
+  const maxRoomID = (league + 1) * 100 - 1
+  let roomID;
+  do {
+    roomID = Math.floor(Math.random()*(maxRoomID - minRoomID + 1) + minRoomID);
+  } while(roomsList.includes(roomID))
+
+  return roomID;
+}
+
+function createRoomAndJoin(league, roomsList, username, id) {
+  const roomID = generateRoomID(league, roomsList);
+
+  let roomObj = {[roomID]:{state : 0, playing : 0, timer :{observableTime:0}}};
+
+  admin.database().ref(parentRoomID).update(roomObj);
+  admin.database().ref(parentRoomID + roomID).update({"users":{[id]:username}});
+
+  return roomID.toString();
+}
+
+function removeRoomData(roomID) {
+  admin.database().ref(parentRoomID + roomID).child("users").remove();
+  admin.database().ref(parentRoomID + roomID).child("ranking").remove();
+  admin.database().ref(parentRoomID + roomID).child("playing").set(PlayingEnum.Idle);
+  admin.database().ref(parentRoomID + roomID).child("state").set(StateEnum.Idle);
+  admin.database().ref(parentRoomID + roomID).child("finished").remove();
+  admin.database().ref(parentRoomID + roomID).child("uploadDrawing").remove();
+}
+
+function removeRoom(roomID) {
+  // Do not remove the testing room 
+  if(roomID !== "0123457890") {
+    admin.database().ref(parentRoomID + roomID).remove();
+  }
+}
+
 exports.onUsersChange = functions.database.ref(parentRoomID + "{roomID}/users").onWrite((change, context) => {
   const roomID = context.params.roomID;
+  let isRoomRemoved = false;
   return admin.database().ref(parentRoomID + roomID).once('value', (snapshot) => {
 
     if(snapshot.hasChild("words") && !snapshot.hasChild("users")) {
       // Remove the words because the room is empty
       admin.database().ref(parentRoomID + roomID + "/words").remove();
+      removeRoom(roomID);
+      isRoomRemoved = true;
     }
     else if(snapshot.hasChild("users") && !snapshot.hasChild("words")) {
       // Generate the words
       addWordsToDatabase(roomID);
     }
 
-    return checkUsersReady(0, parentRoomID + roomID, snapshot);
+    if(isRoomRemoved === false) {
+      checkUsersReady(parentRoomID + roomID, snapshot);
+    }
   });
 });
 
@@ -209,12 +272,11 @@ function startTimer(time, roomID, prevState, newState) {
           return console.log('Timer of ' + totalTime + ' has finished.');
       })
       .then(() => new Promise(resolve => setTimeout(resolve, 1000)))
-      .then(() => admin.database().ref(parentRoomID + roomID + "/timer/endTime").set(1))
       .then(() => admin.database().ref(parentRoomID + roomID + "/state").set(newState))
       .catch(error => console.error(error));
 }
 
-function createRankingNode(roomID) {
+function createNode(roomID, node) {
   updates = {};
   admin.database().ref(parentRoomID + roomID).child("users").once('value', (snapshot) => {
     snapshot.forEach((child) => {
@@ -222,7 +284,7 @@ function createRankingNode(roomID) {
     });
   });
 
-  admin.database().ref(parentRoomID + roomID).child("ranking").once('value', function(snapshot) {
+  admin.database().ref(parentRoomID + roomID).child(node).once('value', function(snapshot) {
     snapshot.ref.set(updates);
   });
 
@@ -245,7 +307,9 @@ exports.onStateUpdate = functions.database.ref(parentRoomID + "{roomID}/state").
       return startTimer(WAITING_TIME_CHOOSE_WORDS, roomID, StateEnum.ChoosingWordsCountdown, StateEnum.DrawingPage);
 
     case StateEnum.DrawingPage:
-      createRankingNode(roomID);
+      createNode(roomID, "ranking");
+      createNode(roomID, "finished");
+      createNode(roomID, "uploadDrawing")
       playingRef.set(PlayingEnum.Playing);
       return startTimer(WAITING_TIME_DRAWING, roomID, StateEnum.DrawingPage, StateEnum.VotingPage);
 
@@ -264,12 +328,9 @@ exports.onStateUpdate = functions.database.ref(parentRoomID + "{roomID}/state").
 exports.onFinishedUpdate = functions.database.ref(parentRoomID + "{roomID}/finished").onWrite((change, context) => {
   const roomID = context.params.roomID;
   return admin.database().ref(parentRoomID + roomID + "/finished").once('value', (snapshot) => {
-    if(snapshot.val() === maxPlayers && roomID !== "0123457890") {
-      admin.database().ref(parentRoomID + roomID).child("users").remove();
-      admin.database().ref(parentRoomID + roomID).child("ranking").remove();
-      admin.database().ref(parentRoomID + roomID).child("playing").set(PlayingEnum.Idle);
-      admin.database().ref(parentRoomID + roomID).child("state").set(StateEnum.Idle);
-      admin.database().ref(parentRoomID + roomID).child("finished").set(0);
+    if(checkNodeTrue(snapshot) === true && roomID !== "0123457890") {
+      removeRoom(roomID);
     }
   });
 });
+


### PR DESCRIPTION
This small PR modifies the end game room deletion. The room are now created dynamically if no room is available and is removed when no user is in the room and finally the vote of a user is removed if this one leaves the room.

- Now every player has to set to 1 (finished field) in the database for the room to be deleted.

- If no room is available when when searching for a room, it automatically creates a new one.

- If no player is in the room or all the childs of "finished" (in the db) are set to 1 the room is deleted.

- If a player already voted on a word and leaves the room afterwards this vote gets removed 